### PR TITLE
FIX – Update Podspec Resource Key from "Resources" to "IterableSDK"

### DIFF
--- a/Iterable-iOS-SDK.podspec
+++ b/Iterable-iOS-SDK.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.3'
 
-  s.resource_bundles = {'Resources' => 'swift-sdk/Resources/**/*.{storyboard,xib,xcassets,xcdatamodeld}' }
+  s.resource_bundles = {'IterableSDK' => 'swift-sdk/Resources/**/*.{storyboard,xib,xcassets,xcdatamodeld}' }
 
   s.header_dir = 'IterableSDK'
 end


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)
* https://tapcart.atlassian.net/browse/IOS-748

## ✏️ Description

> Please provide a brief description of what this pull request does.

This PR renames the resources bundle key name from `Resources` to `IterableSDK`.  The purpose for this change comes from an Xcode error that says "Multiple commands produce 'Resources.bundle'" during the archiving process of the Tapcart app. After failing attempts of similar changes in our Tapcart Tracker SDK (which also creates a Resources folder), the one solution that worked was to fork the Iterable SDK and make the changes here.
